### PR TITLE
Remove a meta file using the wrong case

### DIFF
--- a/Visualisation/Resources/Visualiser/Prefab/liquorice.prefab.meta
+++ b/Visualisation/Resources/Visualiser/Prefab/liquorice.prefab.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 6b5cf0e13b3e36149adb2e6cb6acf737
-PrefabImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The file has the same name as another with just the case being different. It is an issue on windows where the file system is not case-sensitive. It generates the following error when building a project in Unity:

```
Case sensitive file systems are not fully supported, please move or rename these files.
(Filename: ./Modules/AssetDatabase/Editor/V2/SourceAssetDB.cpp Line: 829)
The following files have the same name but only differ in casing and will be ignored:
	Assets/Plugins/Narupa/Visualisation/Resources/Visualiser/Prefab/Liquorice.prefab.meta
	Assets/Plugins/Narupa/Visualisation/Resources/Visualiser/Prefab/liquorice.prefab.meta
```