### PR TITLE
Suppress useless warnings

### DIFF
--- a/Frontend/UI/FloatingCanvas.cs
+++ b/Frontend/UI/FloatingCanvas.cs
@@ -12,8 +12,10 @@ using UnityEngine.Assertions;
         [SerializeField]
         private float verticalOffset;
 
+#pragma warning disable 0109
         [SerializeField]
         private new Camera camera;
+#pragma warning restore 0109
 
         [SerializeField]
         private float smoothTime;

--- a/Frontend/UI/WorldSpaceCursorInput.cs
+++ b/Frontend/UI/WorldSpaceCursorInput.cs
@@ -14,10 +14,10 @@ namespace Nanover.Frontend.UI
     {
         private static WorldSpaceCursorInput Instance { get; set; }
 
-#pragma warning disable 0649
+#pragma warning disable 0649, 0109
         [SerializeField]
-        new private Camera camera;
-#pragma warning restore 0649
+        private new Camera camera;
+#pragma warning restore 0649, 0109
 
         private IPosedObject cursor;
         private Canvas canvas;

--- a/Grpc/GrpcConnection.cs
+++ b/Grpc/GrpcConnection.cs
@@ -71,12 +71,13 @@ namespace Nanover.Grpc
             if (IsCancelled)
                 return;
 
-            //await Channel.ShutdownAsync();
             CancellationTokenSource?.Cancel();
             CancellationTokenSource?.Dispose();
             Channel?.Dispose();
             Channel = null;
             CancellationTokenSource = null;
+
+            await Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
If you use `private new Camera camera` Unity will realise you never use `camera` member of `MonoBehaviour` and never compile it, causing the warning because no such field exists. If you use `private Camera camera` Unity will not realise you aren't using the `camera` member and leave it in, causing the warning that you should use `new`. You can't win!