### PR TITLE
Handle residues missing named atoms

### DIFF
--- a/Visualisation/Node/Protein/DsspAlgorithm.cs
+++ b/Visualisation/Node/Protein/DsspAlgorithm.cs
@@ -62,6 +62,35 @@ namespace Nanover.Visualisation.Node.Protein
                 }
             }
 
+            // Guess missing atoms
+            for (var i = 0; i < atomResidues.Length; i++)
+            {
+                var name = atomNames[i];
+                var residueIndex = atomResidues[i];
+                if (!residueIndexToOrdinal.ContainsKey(residueIndex))
+                    continue;
+
+                var data = list[residueIndexToOrdinal[residueIndex]];
+
+                if (data.HasEssentialNamedAtoms)
+                    continue;
+
+                if (data.AlphaCarbonIndex < 0 && name.StartsWith("C"))
+                    data.AlphaCarbonIndex = i;
+
+                if (data.CarbonIndex < 0 && name.StartsWith("C"))
+                    data.CarbonIndex = i;
+
+                if (data.NitrogenIndex < 0 && name.StartsWith("N"))
+                    data.NitrogenIndex = i;
+
+                if (data.OxygenIndex < 0 && name.StartsWith("O"))
+                    data.OxygenIndex = i;
+
+                if (data.HydrogenIndex < 0 && name.StartsWith("H"))
+                    data.HydrogenIndex = i;
+            }
+
             return list;
         }
 
@@ -70,6 +99,9 @@ namespace Nanover.Visualisation.Node.Protein
         {
             foreach (var residue in residues)
             {
+                if (!residue.HasEssentialNamedAtoms)
+                    continue;
+
                 residue.AlphaCarbonPosition = atomPositions[residue.AlphaCarbonIndex];
                 residue.NitrogenPosition = atomPositions[residue.NitrogenIndex];
                 residue.OxygenPosition = atomPositions[residue.OxygenIndex];

--- a/Visualisation/Node/Protein/SecondaryStructureResidueData.cs
+++ b/Visualisation/Node/Protein/SecondaryStructureResidueData.cs
@@ -7,6 +7,11 @@ namespace Nanover.Visualisation.Node.Protein
     /// </summary>
     public class SecondaryStructureResidueData
     {
+        public bool HasEssentialNamedAtoms => AlphaCarbonIndex >= 0
+                                           && CarbonIndex >= 0
+                                           && NitrogenIndex >= 0
+                                           && OxygenIndex >= 0;
+
         /// <summary>
         /// Index of the alpha carbon.
         /// </summary>


### PR DESCRIPTION
I have a system that contains residues like this that the cartoon renderer's DSSP can handle:
```
ATOM   7079  N   TRP B 431      76.610  84.450 121.710  1.00  0.00           N
ATOM   7080  H   TRP B 431      77.000  85.150 121.080  1.00  0.00           H
ATOM   7081  CA  TRP B 431      76.790  84.690 123.140  1.00  0.00           C
ATOM   7082  HA  TRP B 431      76.230  83.950 123.710  1.00  0.00           H
ATOM   7083  CB  TRP B 431      78.260  84.630 123.570  1.00  0.00           C
ATOM   7084  HB1 TRP B 431      78.300  84.530 124.650  1.00  0.00           H
ATOM   7085  HB2 TRP B 431      78.720  85.590 123.330  1.00  0.00           H
ATOM   7086  CG  TRP B 431      79.140  83.570 122.970  1.00  0.00           C
ATOM   7087  CD1 TRP B 431      78.750  82.400 122.430  1.00  0.00           C
ATOM   7088  HD1 TRP B 431      77.720  82.060 122.350  1.00  0.00           H
ATOM   7089  NE1 TRP B 431      79.830  81.750 121.880  1.00  0.00           N
ATOM   7090  HE1 TRP B 431      79.730  80.940 121.280  1.00  0.00           H
ATOM   7091  CE2 TRP B 431      81.000  82.450 122.090  1.00  0.00           C
ATOM   7092  CZ2 TRP B 431      82.340  82.200 121.750  1.00  0.00           C
ATOM   7093  HZ2 TRP B 431      82.600  81.330 121.170  1.00  0.00           H
ATOM   7094  CH2 TRP B 431      83.320  83.100 122.170  1.00  0.00           C
ATOM   7095  HH2 TRP B 431      84.360  82.940 121.900  1.00  0.00           H
ATOM   7096  CZ3 TRP B 431      82.960  84.260 122.880  1.00  0.00           C
ATOM   7097  HZ3 TRP B 431      83.720  84.990 123.130  1.00  0.00           H
ATOM   7098  CE3 TRP B 431      81.610  84.510 123.200  1.00  0.00           C
ATOM   7099  HE3 TRP B 431      81.350  85.430 123.710  1.00  0.00           H
ATOM   7100  CD2 TRP B 431      80.600  83.610 122.820  1.00  0.00           C
ATOM   7101  C   TRP B 431      76.210  86.080 123.470  1.00  0.00           C
ATOM   7102  O   TRP B 431      76.340  86.990 122.650  1.00  0.00           O
```

But some like this which it can't.
```
ATOM   6148  N   TRP A 374      99.480  68.370  87.140  1.00  0.00           N
ATOM   6149  H   TRP A 374      98.970  69.230  87.200  1.00  0.00           H
ATOM   6150  CA  TRP A 374     100.850  68.440  86.560  1.00  0.00           C
ATOM   6151  HA  TRP A 374     101.140  67.450  86.220  1.00  0.00           H
ATOM   6152  CB  TRP A 374     100.860  69.370  85.320  1.00  0.00           C
ATOM   6153  HB1 TRP A 374     101.890  69.620  85.090  1.00  0.00           H
ATOM   6154  HB2 TRP A 374     100.370  70.310  85.580  1.00  0.00           H
ATOM   6155  CG  TRP A 374     100.270  68.840  84.040  1.00  0.00           C
ATOM   6156  CD1 TRP A 374      99.270  67.930  83.940  1.00  0.00           C
ATOM   6157  HD1 TRP A 374      98.770  67.490  84.780  1.00  0.00           H
ATOM   6158  NE1 TRP A 374      99.000  67.680  82.610  1.00  0.00           N
ATOM   6159  HE1 TRP A 374      98.270  67.050  82.320  1.00  0.00           H
ATOM   6160  CE2 TRP A 374      99.830  68.370  81.770  1.00  0.00           C
ATOM   6161  CZ2 TRP A 374      99.980  68.410  80.380  1.00  0.00           C
ATOM   6162  HZ2 TRP A 374      99.360  67.790  79.750  1.00  0.00           H
ATOM   6163  CH2 TRP A 374     100.970  69.230  79.820  1.00  0.00           C
ATOM   6164  HH2 TRP A 374     101.130  69.240  78.750  1.00  0.00           H
ATOM   6165  CZ3 TRP A 374     101.780  70.020  80.650  1.00  0.00           C
ATOM   6166  HZ3 TRP A 374     102.540  70.660  80.220  1.00  0.00           H
ATOM   6167  CE3 TRP A 374     101.610  69.990  82.050  1.00  0.00           C
ATOM   6168  HE3 TRP A 374     102.240  70.590  82.690  1.00  0.00           H
ATOM   6169  CD2 TRP A 374     100.650  69.150  82.660  1.00  0.00           C
ATOM   6170  C   TRP A 374     101.910  68.780  87.640  1.00  0.00           C
ATOM   6171  OC1 TRP A 374     102.960  69.340  87.270  1.00  0.00           O
ATOM   6172  OC2 TRP A 374     101.700  68.410  88.810  1.00  0.00           O
```

The difference here is that the latter doesn't have an atom named `O` but instead `OC1` and `OC2`. The `O` is used for aligning the rendering and also for determining hydrogen bonds (but I don't really understand much of how it works).

This request handles this case by firstly just falling back to any atom that has the right letter, if the atom is missing, and secondly by skipping alignment if the required atom is missing.

Maybe someone with MD knowledge knows a better way to deal with this?